### PR TITLE
Fix subdomain flag issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ You can build the tool by running `make`. That's it!
 
 ## Running the tool
 
-Run the tool by running `./website [command]`. For a more comprehensive guide on all commands, run `./website help`.
+Run the tool by running `./website (-sudomain [domain]) [command]`. For a more comprehensive guide on all commands, run `./website help`.
 
 A few of the most useful commands are below:
 
 - `preview`: builds the website and previews it locally at http://localhost:1313.
-- `deploy`: builds the website and uploads it to the webhost. Requires subdomain flag, ex. `subdomain simon`.
+- `deploy`: builds the website and uploads it to the webhost. Requires subdomain flag, ex. `./website -subdomain simon deploy`.
 - `rollback`: if there's a mistake in the `deploy` command, you can run this command with the same subdomain flag as before to rollback the website on the webhost to what was there before.

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	flag.Parse()
 
 	args := flag.Args()
-	if len(args) != 1 {
+	if len(args) == 0 {
 		fmt.Println("Error: did not specify command. Try 'help' command.")
 		return
 	}


### PR DESCRIPTION
There's an issue where if you provide the subdomain flag, the command errors out because we check that only 1 argument is provided. The tool used to not allow flags, but now that we allow subdomain flags I've decided to make the tool more permissive and only check whether 0 arguments were provided.