### PR TITLE
Fix subdomian issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -606,5 +606,5 @@ const HUGO_BUILD_DIRECTORY = "public"
 
 // root of the website, ie. /home/[username]/public_html/simon.duchastel.com
 func websiteRemoteRoot(username string) string {
-	return "/home/" + username + "/public_html/" + subDomain
+	return "/home/" + username + "/public_html/" + getSupportedSubDomains()[subDomain].text
 }


### PR DESCRIPTION
There was an issue where the subdomain command was being used to lookup the directory on the remote server. This caused a failure when running `upload`, `deploy`, and `rollback` commands.

The fix is to use subdomain directory rather than the command name instead (which means referring to the subdomain map).

ie. we should not use `simon` when uploading files to GoDaddy - we should use `simon.duchastel.com` (`simon` is the command and the index of the struct containing the directory to lookup).