### PR TITLE
Fix file path separator bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -574,9 +574,11 @@ func uploadWebsite(remoteWebsiteRoot, siteToUploadLocation string, sshClient *ss
 		}
 
 		if !file.IsDir() && len(path) > 0 {
+			// note that we don't need to localize the file path on the remote system because we know it's unix (ie. uses '/')
 			uploadFilePath := remoteWebsiteRoot + "/" + strings.TrimPrefix(path, siteToUploadLocation+"/")
+			pathOsLocalized := filepath.FromSlash(path) // localize the path to whatever separator is used on this system
 			fmt.Println("  Uploading " + path)
-			if err := uploadFile(sshClient, path, uploadFilePath); err != nil {
+			if err := uploadFile(sshClient, pathOsLocalized, uploadFilePath); err != nil {
 				fmt.Println("Error: failed to upload file '" + path + "'")
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func getSupportedSubDomains() map[string]StringAndBool {
 	// Map of sub-domain values in CLI to path to store files on server and if we support certs renewal.
 	return map[string]StringAndBool{
 		"simon":      {"simon.duchastel.com", true},
+		"mr":         {"mr.duchastel.com", true},
 		"nicolas":    {"nicolas.duchastel.com", true},
 		"pointbolin": {"pointbolin.com", true},
 		"com":        {"duchastel.com", true},


### PR DESCRIPTION
The program assumes all file path separators are '/'. On windows however, this is not true (could be the case on other OS's as well). Note that we don't need to change the path separators on the remote host, since we know it's unix (in fact we *shouldn't* localize them, since we don't want to use the windows separator for the remote unix box).