### PR TITLE
Add dry run flag, fix file path for unix remote box

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ A few of the most useful commands are below:
 - `preview`: builds the website and previews it locally at http://localhost:1313.
 - `deploy`: builds the website and uploads it to the webhost. Requires subdomain flag, ex. `./website -subdomain simon deploy`.
 - `rollback`: if there's a mistake in the `deploy` command, you can run this command with the same subdomain flag as before to rollback the website on the webhost to what was there before.
+
+## Flags
+
+- `-dry-run`: Print verbose debugging of all actions being taken, but don't execute anything (ex. don't upload files). Useful for testing.

--- a/main.go
+++ b/main.go
@@ -442,8 +442,6 @@ func uploadFile(client *ssh.Client, sourceFilePath, destinationFilePath string) 
 			fmt.Println("Error: failed to copy file '" + sourceFilePath + "' to remote server")
 			return err
 		}
-	} else {
-		fmt.Println("Uploading file " + sourceFilePath + " to " + destinationFilePath)
 	}
 
 	return nil
@@ -563,12 +561,14 @@ func downloadOldSite(remoteWebsiteRoot, oldSiteDownloadLocation string, sshClien
 	// clear old website directory in preparation for storing old website
 	// ensure the website follows the local-OS style file path separators
 	osOldSiteDownloadLocation := filepath.FromSlash(oldSiteDownloadLocation)
-	fmt.Println("Clearing old site at " + osOldSiteDownloadLocation)
 	if !isDryRun {
+		fmt.Println("Clearing old site")
 		if err := os.RemoveAll(osOldSiteDownloadLocation); err != nil {
 			fmt.Println("Error: cannot clear '" + oldSiteDownloadLocation + "' directory")
 			return err
 		}
+	} else {
+		fmt.Println("Clearing old site at " + osOldSiteDownloadLocation)
 	}
 
 	if len(files) <= 0 {
@@ -581,11 +581,13 @@ func downloadOldSite(remoteWebsiteRoot, oldSiteDownloadLocation string, sshClien
 		trimmedFile := strings.TrimPrefix(unixFile, unixRemoteWebsiteRoot+"/")
 		destinationFile := unixOldSiteDownloadLocation + "/" + trimmedFile
 
-		fmt.Println("  Downloading " + file)
 		if !isDryRun {
+			fmt.Println("  Downloading " + unixFile)
 			if err := downloadRemoteFile(sshClient, unixFile, destinationFile); err != nil {
 				return err
 			}
+		} else {
+			fmt.Println("  Downloading " + unixFile + " to " + destinationFile)
 		}
 	}
 	return nil
@@ -594,11 +596,13 @@ func downloadOldSite(remoteWebsiteRoot, oldSiteDownloadLocation string, sshClien
 func uploadWebsite(remoteWebsiteRoot, siteToUploadLocation string, sshClient *ssh.Client) error {
 	// run 'rm -rf' to delete everything in the website directory
 	unixRemoteRoot := filepath.ToSlash(remoteWebsiteRoot)
-	fmt.Println("Removing old website from web host at " + unixRemoteRoot)
 	if !isDryRun {
+		fmt.Println("Removing old website from web host")
 		if _, err := runRemoteCommand(sshClient, "rm -rf "+unixRemoteRoot+"/*"); err != nil {
 			return err
 		}
+	} else {
+		fmt.Println("Removing old website from web host at " + unixRemoteRoot)
 	}
 
 	fmt.Println("Uploading website to web host")
@@ -614,7 +618,11 @@ func uploadWebsite(remoteWebsiteRoot, siteToUploadLocation string, sshClient *ss
 			unixPath := filepath.ToSlash(path)
 			uploadFilePath := unixRemoteRoot + "/" + strings.TrimPrefix(unixPath, osSiteUploadLocation+"/")
 			osPath := filepath.FromSlash(path)
-			fmt.Println("  Uploading " + osPath + " to " + uploadFilePath)
+			if !isDryRun {
+				fmt.Println("  Uploading " + osPath)
+			} else {
+				fmt.Println("  Uploading " + osPath + " to " + uploadFilePath)
+			}
 			if err := uploadFile(sshClient, osPath, uploadFilePath); err != nil {
 				fmt.Println("Error: failed to upload file '" + path + "'")
 				return err

--- a/main.go
+++ b/main.go
@@ -574,9 +574,9 @@ func uploadWebsite(remoteWebsiteRoot, siteToUploadLocation string, sshClient *ss
 		}
 
 		if !file.IsDir() && len(path) > 0 {
-			// note that we don't need to localize the file path on the remote system because we know it's unix (ie. uses '/')
-			uploadFilePath := remoteWebsiteRoot + "/" + strings.TrimPrefix(path, siteToUploadLocation+"/")
-			pathOsLocalized := filepath.FromSlash(path) // localize the path to whatever separator is used on this system
+			// ensure that the upload path is unix-style (ie. "/") and ensure the local path is OS-style (whatever system this program is running on)
+			uploadFilePath := filepath.ToSlash(remoteWebsiteRoot + "/" + strings.TrimPrefix(path, siteToUploadLocation+"/"))
+			pathOsLocalized := filepath.FromSlash(path)
 			fmt.Println("  Uploading " + path)
 			if err := uploadFile(sshClient, pathOsLocalized, uploadFilePath); err != nil {
 				fmt.Println("Error: failed to upload file '" + path + "'")

--- a/main.go
+++ b/main.go
@@ -578,7 +578,7 @@ func uploadWebsite(remoteWebsiteRoot, siteToUploadLocation string, sshClient *ss
 
 		if !file.IsDir() && len(path) > 0 {
 			// ensure that the upload path is unix-style (ie. "/") and ensure the local path is OS-style (whatever system this program is running on)
-			uploadFilePath := filepath.ToSlash(remoteWebsiteRoot + "/" + strings.TrimPrefix(path, siteToUploadLocation+"/"))
+			uploadFilePath := filepath.ToSlash(remoteWebsiteRoot + "/" + strings.TrimPrefix(path, siteToUploadLocation+string(os.PathSeparator)))
 			pathOsLocalized := filepath.FromSlash(path)
 			fmt.Println("  Uploading " + path)
 			if err := uploadFile(sshClient, pathOsLocalized, uploadFilePath); err != nil {


### PR DESCRIPTION
My fix in #6 didn't work. While talking with @nduchastel I realized that the path I was specifying on the remote unix webserver was using whatever the file separators the local system was using, meaning that the remote box didn't have the correct separators.

Using `filepath.ToSlash()` on the upload path (ie. what will be used on the remote server) works to normalize everything to the remote box's file separators.

I also added a -dry-run flag, which prints out all the actions being executed but doesn't actually execute the actions (useful for testing).